### PR TITLE
kas: common.yml: update meta-pcengines and meta-trenchboot

### DIFF
--- a/kas/common.yml
+++ b/kas/common.yml
@@ -25,11 +25,11 @@ repos:
 
   meta-pcengines:
     url: https://github.com/3mdeb/meta-pcengines
-    refspec: 897a80228e7834d5a8c0d23e8616085c3cbc46c5
+    refspec: 4e36ba57ec9d916d3b1baa18f20e582593e8bd9c
 
   meta-trenchboot:
     url: https://github.com/3mdeb/meta-trenchboot
-    refspec: 0b176f30ac3d9a2cdb4e089a586b000b1b6163e4
+    refspec: 56790fc536b3d8da482f92598a65eb7967332361
 
 bblayers_conf_header:
   standard: |


### PR DESCRIPTION
Change boot medium to mmc

Signed-off-by: Tomasz Żyjewski <tomasz.zyjewski@3mdeb.com>

<!--
Version: 0.1.0

Instruction

This template is designed to help systematize the submitted pull requests. It
should be placed in `.github/pull_request_template.md` of every repository.

When submitting a given PR for review, please complete the sections below. When
a given section is not applicable in a given case, please complete it with the
abbreviation `N/A`.

The reviewer should start the review only after the submitting person check the
`Pre-review checks are complete` box.
-->
## Overview

This PR change root flag in used grub.cfg from /dev/sda2 to /dev/mmcblk0p2

## List of issues

N/A

## Evidence

Now system can boot when `secure-boot` option is selected. The config
looks as follows

```
menuentry 'secure-boot'{
  slaunch skinit
  slaunch_module (hd0,msdos1)/lz_header.bin
  linux /bzImage root=/dev/mmcblk0p2 console=ttyS0,115200 earlyprintk=serial,ttyS0,115200
}
```

## Documentation changes

N/A

## Notes/known issues

* `secure-boot` option in GRUB needs to be selected manually

## Pre-review checklist

- :bangbang: Document changes made in above template
- :bangbang: Document how the changes work (screenshots, demo, CLI tests, etc)
- :bangbang: Changes added to CHANGELOG
- :bangbang: Version bumped
- :bangbang: Documents wrapped at 80 chars
- [x] Pre-review checks are complete

## Reviewer

- [x] Reviewer checks are complete
- :bangbang: Does the change match the task criteria
- :bangbang: Does it work as explained in `Evidence` section
