### PR TITLE
Attester autostart

### DIFF
--- a/meta-fobnail-distro/recipes-fobnail/fobnail-attester/files/fobnail-attester.service
+++ b/meta-fobnail-distro/recipes-fobnail/fobnail-attester/files/fobnail-attester.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=fobnail attester service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/fobnail-attester
+StandardOutput=journal+console
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-fobnail-distro/recipes-fobnail/fobnail-attester/fobnail-attester_git.bb
+++ b/meta-fobnail-distro/recipes-fobnail/fobnail-attester/fobnail-attester_git.bb
@@ -12,6 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1ff626c483f6f10b69ee67274daf0775"
 SRC_URI = " \
     git://github.com/fobnail/fobnail-attester;protocol=https;branch=main \
     file://0001-Makefile-fix-to-build-in-Yocto.patch \
+    file://fobnail-attester.service \
 "
 
 DEPENDS = "openssl tpm2-tss libcoap qcbor"
@@ -28,4 +29,15 @@ do_install() {
     # instalation of fobnail-attester executable binary
     install -d ${D}${bindir}
     install -m 755 ${S}/bin/fobnail-attester ${D}${bindir}
+
+    install -m 0755 -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/fobnail-attester.service ${D}${systemd_unitdir}/system/
 }
+
+SYSTEMD_SERVICE:${PN} = " \
+    fobnail-attester.service \
+"
+
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+inherit systemd


### PR DESCRIPTION
<!--
Version: 0.1.0

Instruction

This template is designed to help systematize the submitted pull requests. It
should be placed in `.github/pull_request_template.md` of every repository.

When submitting a given PR for review, please complete the sections below. When
a given section is not applicable in a given case, please complete it with the
abbreviation `N/A`.

The reviewer should start the review only after the submitting person check the
`Pre-review checks are complete` box.
-->
## Overview

This PR introduces new systemd service for `fobnail-attester`

## List of issues

N/A

## Evidence

```
# systemctl status fobnail-attester
* fobnail-attester.service - fobnail attester service
     Loaded: loaded (8;;file://tb/lib/systemd/system/fobnail-attester.service/lib/systemd/system/fobnail-attester.service8;;; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2022-05-18 08:49:34 UTC; 3min 23s ago
   Main PID: 222 (fobnail-atteste)
      Tasks: 1 (limit: 4702)
     Memory: 3.6M
     CGroup: /system.slice/fobnail-attester.service
             `-222 /usr/bin/fobnail-attester

May 18 08:49:34 tb systemd[1]: Started fobnail attester service.
```

## Documentation changes

N/A

## Notes/known issues

N/A

## Pre-review checklist

- :bangbang: Document changes made in above template
- :bangbang: Document how the changes work (screenshots, demo, CLI tests, etc)
- :bangbang: Changes added to CHANGELOG
- :bangbang: Version bumped
- :bangbang: Documents wrapped at 80 chars
- [x] Pre-review checks are complete

## Reviewer

- [x] Reviewer checks are complete
- :bangbang: Does the change match the task criteria
- :bangbang: Does it work as explained in `Evidence` section
